### PR TITLE
feat: configure `renovate` within the generated template

### DIFF
--- a/template/.github/renovate.json5
+++ b/template/.github/renovate.json5
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "custom.regex",
+  ],
+  "extends": [
+    "config:recommended",
+    ":semanticCommitTypeAll(fix)",
+  ],
+  # there are two match strings to match the two conditions
+  #   * no update needed
+  #   * update needed but not yet applied
+  # renovate needs to be able to match both conditions for PRs to work properly
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.copier-answers.yml$"],
+      "matchStrings": [
+        "_commit: (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>\\S+)\\n",
+        "_commit: \\S+ # __copier_update_needed (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>.*)\\n",
+      ],
+      "datasourceTemplate": "github-tags",
+      "autoReplaceStringTemplate": "_commit: {{{currentValue}}} # __copier_update_needed {{{newValue}}}\n_src_path: gh:{{{depName}}}\n",
+    }
+  ]
+}

--- a/test/GenerateProject/catalogue.tt
+++ b/test/GenerateProject/catalogue.tt
@@ -2,6 +2,7 @@ The following new files/directories were created:
 <Test Directory>
 ----.copier-answers.yml
 ----.github
+--------renovate.json5
 --------workflows
 ------------main.yml
 ----.pre-commit-config.yaml

--- a/test/GenerateProject/renovate_json5.tt
+++ b/test/GenerateProject/renovate_json5.tt
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "custom.regex",
+  ],
+  "extends": [
+    "config:recommended",
+    ":semanticCommitTypeAll(fix)",
+  ],
+  # there are two match strings to match the two conditions
+  #   * no update needed
+  #   * update needed but not yet applied
+  # renovate needs to be able to match both conditions for PRs to work properly
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.copier-answers.yml$"],
+      "matchStrings": [
+        "_commit: (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>\\S+)\\n",
+        "_commit: \\S+ # __copier_update_needed (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>.*)\\n",
+      ],
+      "datasourceTemplate": "github-tags",
+      "autoReplaceStringTemplate": "_commit: {{{currentValue}}} # __copier_update_needed {{{newValue}}}\n_src_path: gh:{{{depName}}}\n",
+    }
+  ]
+}

--- a/test/config.tt
+++ b/test/config.tt
@@ -16,3 +16,4 @@ config_tt:test/config.tt
 copier_yaml:copier.yaml
 main_yml:.github/workflows/main.yml
 pre-commit_yaml:.pre-commit-config.yaml
+renovate_json5:.github/renovate.json5


### PR DESCRIPTION
* the generated `renovate` config is to track updates of the source `copier` template
